### PR TITLE
Update intent filter to use less ambiguous action

### DIFF
--- a/assignments/assignment1/AndroidManifest.xml
+++ b/assignments/assignment1/AndroidManifest.xml
@@ -29,7 +29,7 @@
        android:name=".DownloadImageActivity"
        android:label="@string/download_image_activity">
       <intent-filter>
-        <action android:name="android.intent.action.WEB_SEARCH" />
+        <action android:name="android.intent.action.IMAGE_DOWNLOAD" />
         <category android:name="android.intent.category.DEFAULT" />
         <data android:scheme="http" />
         <data android:scheme="https" />


### PR DESCRIPTION
Only manifest file changed. By using this action it will not trigger chooser containing web browser to show which could not actually complete the action we need.