### PR TITLE
Return null for bad URL

### DIFF
--- a/assignments/assignment1/src/vandy/mooc/DownloadUtils.java
+++ b/assignments/assignment1/src/vandy/mooc/DownloadUtils.java
@@ -145,6 +145,7 @@ public class DownloadUtils {
             inputStream.close();
         } catch (Exception e) {
             e.printStackTrace();
+            return null;
         }
 
         // Get the absolute path of the image.


### PR DESCRIPTION
I haven't done a pull request before, so this could be royally messed up.  If so, sorry.

This is the change I intended from the Discussion Forum.  Perhaps this mechanism removes any ambiguity.  Now any exception that gets thrown in the try block causes null to be returned, so the error can be detected.

(And thanks for all the work involved in putting the class together.)