### PR TITLE
ending DelayedOutputThread thread after done message

### DIFF
--- a/assignments/assignment2/src/vandy/mooc/MainActivity.java
+++ b/assignments/assignment2/src/vandy/mooc/MainActivity.java
@@ -119,6 +119,12 @@ public class MainActivity extends Activity {
         case RESET:
             // Stop the thread that handles calls to print();
             mDelayedOutputThread.interrupt();
+            mDelayedOutputThread.runOnDelayedOutputThread(new Runnable() {
+                @Override
+                public void run() {
+                    Looper.myLooper().quit();
+                }
+            });
         	
             // Reset the color output.
             mPingPongColorOutput.setText("");


### PR DESCRIPTION
The Thread interrupt method dont interrupt the MessageQueue next method.
The DelayedOutputThread never end when the queue is empty.