### PR TITLE
fixed typo on communication URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ POSA-15
 This repository contains assignments and examples for the 2015
 offering of the Pattern-Oriented Software Architecture (POSA) MOOCs
 (see www.coursera.org/course/posaconcurrency and
-www.coursera.org/posacommunication for more information).
+www.coursera.org/course/posacommunication for more information).


### PR DESCRIPTION
POSA communication course URL had 'course' missing. Corrected this URL to "www.coursera.org/course/posacommunication"