### PR TITLE
Setter methods to the RequestReplyMessageBase class 

### DIFF
--- a/assignments/assignment2/src/vandy/mooc/utils/ReplyMessage.java
+++ b/assignments/assignment2/src/vandy/mooc/utils/ReplyMessage.java
@@ -41,23 +41,21 @@ public class ReplyMessage extends RequestReplyMessageBase {
         // Create a new Bundle to handle the result.
         // TODO -- you fill in here.
 
-        // Put the URL to the image file into the Bundle via the
-        // IMAGE_URL key.
+        // Set the Bundle to be the data in the message.
         // TODO -- you fill in here.
 
-        // Put the requestCode into the Bundle via the REQUEST_CODE
-        // key.
+        // Put the URL to the image file into the Bundle
         // TODO -- you fill in here.
 
-        // Set a field in the Message to indicate whether the download
+        // Put the requestCode into the Bundle
+        // TODO -- you fill in here.
+
+        // Set the result code to indicate whether the download
         // succeeded or failed.
         // TODO -- you fill in here.
 
-        // Put the path to the image file into the Bundle via the
-        // IMAGE_PATHNAME key only if the download succeeded.
-        // TODO -- you fill in here.
-
-        // Set the Bundle to be the data in the message.
+        // Put the path to the image file into the Bundle
+        // only if the download succeeded.
         // TODO -- you fill in here.
 
         return replyMessage;

--- a/assignments/assignment2/src/vandy/mooc/utils/RequestMessage.java
+++ b/assignments/assignment2/src/vandy/mooc/utils/RequestMessage.java
@@ -46,19 +46,16 @@ public class RequestMessage extends RequestReplyMessageBase {
         // Create a new Bundle to handle the result.
         // TODO -- you fill in here.
 
-        // Put the URL to the image file into the Bundle via the
-        // IMAGE_URL key.
-        // TODO -- you fill in here.
-
-        // Put the pathname to the image file into the Bundle via the
-        // DIRECTORY_PATHNAME key.
-        // TODO -- you fill in here.
-
-        // Put the request code into the Bundle via the REQUEST_CODE
-        // key.
-        // TODO -- you fill in here.
-
         // Set the Bundle as the "data" for the Message.
+        // TODO -- you fill in here.
+
+        // Put the URL to the image file into the Bundle
+        // TODO -- you fill in here.
+
+        // Put the pathname to the image file into the Bundle
+        // TODO -- you fill in here.
+
+        // Put the request code into the Bundle
         // TODO -- you fill in here.
 
         // Return the message to the caller.

--- a/assignments/assignment2/src/vandy/mooc/utils/RequestReplyMessageBase.java
+++ b/assignments/assignment2/src/vandy/mooc/utils/RequestReplyMessageBase.java
@@ -14,24 +14,24 @@ class RequestReplyMessageBase {
      * String constant used to extract the pathname to a downloaded
      * image from a Bundle.
      */
-    protected static final String IMAGE_PATHNAME = "IMAGE_PATHNAME";
+    private static final String IMAGE_PATHNAME = "IMAGE_PATHNAME";
 
     /**
      * String constant used to extract the request code.
      */
-    protected static final String REQUEST_CODE = "REQUEST_CODE";
+    private static final String REQUEST_CODE = "REQUEST_CODE";
 
     /**
      * String constant used to extract the URL to an image from a
      * Bundle.
      */
-    protected static final String IMAGE_URL = "IMAGE_URL";
+    private static final String IMAGE_URL = "IMAGE_URL";
 
     /**
      * String constant used to extract the directory pathname to use
      * to store a downloaded image.
      */
-    protected static final String DIRECTORY_PATHNAME = "DIRECTORY_PATHNAME";
+    private static final String DIRECTORY_PATHNAME = "DIRECTORY_PATHNAME";
     
     /**
      * Message used to hold the information.
@@ -61,6 +61,14 @@ class RequestReplyMessageBase {
     }
 
     /**
+     * Sets provided Bundle as the data of the underlying Message
+     * @param data - the Bundle to set
+     */
+    public void setData(Bundle data) {
+        mMessage.setData(data);
+    }
+
+    /**
      * Accessor method that returns the result code of the message, which
      * can be used to check if the download succeeded.
      */
@@ -69,12 +77,28 @@ class RequestReplyMessageBase {
     }
 
     /**
+     * Accessor method that sets the result code
+     * @param resultCode - the code too set
+     */
+    public void setResultCode(int resultCode) {
+        mMessage.arg1 = resultCode;
+    }
+
+    /**
      * Accessor method that returns Messenger of the Message.
      */
     public Messenger getMessenger() {
       return mMessage.replyTo;
     }
-    
+
+    /**
+     * Accessor method that sets Messenger of the Message
+     * @param messenger
+     */
+    public void setMessenger(Messenger messenger) {
+        mMessage.replyTo = messenger;
+    }
+
     /**
      * Accessor method that returns the request code of the message.
      */
@@ -88,12 +112,29 @@ class RequestReplyMessageBase {
     }
 
     /**
+     * Accessor method that sets the request code of the message
+     * @param requestCode
+     */
+    public void setRequestCode(int requestCode) {
+        mMessage.getData().putInt(REQUEST_CODE,requestCode);
+    }
+
+    /**
      * Helper method that returns the URL to the image file.
      */
     public static Uri getImageURL(Bundle data) {
         // Extract the path to the image file from the Bundle, which
         // should be stored using the IMAGE_URL key.
         return Uri.parse(data.getString(IMAGE_URL));
+    }
+
+    /**
+     *  Helper method that sets the URL to the image file into provided Bundle
+     * @param data - the Bundle to store the URL
+     * @param url - URL to the image file
+     */
+    public static void setImageURL(Bundle data, Uri url) {
+        data.putString(IMAGE_URL,url.toString());
     }
 
     /**
@@ -110,6 +151,14 @@ class RequestReplyMessageBase {
     }
 
     /**
+     * Helper method that sets the URL to the image file
+     * @param url
+     */
+    public void setImageURL(Uri url) {
+        mMessage.getData().putString(IMAGE_URL,url.toString());
+    }
+
+    /**
      * Helper method that returns the path to the image file if it is
      * download successfully.
      */
@@ -117,6 +166,15 @@ class RequestReplyMessageBase {
         // Extract the path to the image file from the Bundle, which
         // should be stored using the IMAGE_PATHNAME key.
         return data.getString(IMAGE_PATHNAME);
+    }
+
+    /**
+     * Helper method that sets the path to the image file into provided Bundle
+     * @param data - the Bundle to store the path
+     * @param imagePathname - the path to the image file
+     */
+    public static void setImagePathname(Bundle data, String imagePathname) {
+        data.putString(IMAGE_PATHNAME,imagePathname);
     }
 
     /**
@@ -134,6 +192,14 @@ class RequestReplyMessageBase {
     }
 
     /**
+     * Helper method that sets the path to the image file
+     * @param imagePathname - the path to the image file
+     */
+    public void setImagePathname(String imagePathname) {
+        mMessage.getData().putString(IMAGE_PATHNAME,imagePathname);
+    }
+
+    /**
      * Helper method that returns the URI to the directory pathname.
      */
     public String getDirectoryPathname() {
@@ -144,5 +210,13 @@ class RequestReplyMessageBase {
         // Extract the directory pathname the Bundle, which should be
         // stored using the DIRECTORY_PATHNAME key.
         return data.getString(DIRECTORY_PATHNAME);
+    }
+
+    /**
+     * Helper method that sets the URI to the directory pathname
+     * @param directoryPathname
+     */
+    public void setDirectoryPathname(String directoryPathname) {
+        mMessage.getData().putString(DIRECTORY_PATHNAME,directoryPathname);
     }
 }


### PR DESCRIPTION
To allow the base class RequestReplyMessageBase fully encapsulate the way all the values are stored in the Message new setter methods added symmetrically to the existing getter methods.  The key constants used to store and retrieve values made private as they are no longer needed outside of the class.

In addition TODO texts altered in RequestMessage.java and ReplyMessage.java not to refer to the keys for storing values