### PR TITLE
Two more static factory setters; keys are public again for compatibility

### DIFF
--- a/assignments/assignment2/src/vandy/mooc/utils/RequestReplyMessageBase.java
+++ b/assignments/assignment2/src/vandy/mooc/utils/RequestReplyMessageBase.java
@@ -14,24 +14,24 @@ class RequestReplyMessageBase {
      * String constant used to extract the pathname to a downloaded
      * image from a Bundle.
      */
-    private static final String IMAGE_PATHNAME = "IMAGE_PATHNAME";
+    public static final String IMAGE_PATHNAME = "IMAGE_PATHNAME";
 
     /**
      * String constant used to extract the request code.
      */
-    private static final String REQUEST_CODE = "REQUEST_CODE";
+    public static final String REQUEST_CODE = "REQUEST_CODE";
 
     /**
      * String constant used to extract the URL to an image from a
      * Bundle.
      */
-    private static final String IMAGE_URL = "IMAGE_URL";
+    public static final String IMAGE_URL = "IMAGE_URL";
 
     /**
      * String constant used to extract the directory pathname to use
      * to store a downloaded image.
      */
-    private static final String DIRECTORY_PATHNAME = "DIRECTORY_PATHNAME";
+    public static final String DIRECTORY_PATHNAME = "DIRECTORY_PATHNAME";
     
     /**
      * Message used to hold the information.
@@ -117,6 +117,15 @@ class RequestReplyMessageBase {
      */
     public void setRequestCode(int requestCode) {
         mMessage.getData().putInt(REQUEST_CODE,requestCode);
+    }
+
+    /**
+     * Helper method that sets the request code of the message to the provided Bundle
+     * @param data
+     * @param requestCode
+     */
+    public static void setRequestCode(Bundle data, int requestCode) {
+        data.putInt(REQUEST_CODE,requestCode);
     }
 
     /**
@@ -218,5 +227,14 @@ class RequestReplyMessageBase {
      */
     public void setDirectoryPathname(String directoryPathname) {
         mMessage.getData().putString(DIRECTORY_PATHNAME,directoryPathname);
+    }
+
+    /**
+     * Helper method that sets the URI to the directory pathname to provided Bundle
+     * @param data
+     * @param directoryPathname
+     */
+    public static void setDirectoryPathname(Bundle data, String directoryPathname) {
+        data.putString(DIRECTORY_PATHNAME,directoryPathname);
     }
 }


### PR DESCRIPTION
Added two missing static factory setters methods that set values to provided Bundle

Key constants returned to be public for backward-compatibility with possible earlier code that did not use setters