### PR TITLE
fix to avoid producing equal file names on equal test files

### DIFF
--- a/assignments/assignment2/src/vandy/mooc/utils/Utils.java
+++ b/assignments/assignment2/src/vandy/mooc/utils/Utils.java
@@ -375,7 +375,8 @@ public class Utils {
     static private String getUniqueFilename(final String filename) {
     	
         return Base64.encodeToString((filename
-                                      + System.currentTimeMillis()).getBytes(),
+                                      + System.currentTimeMillis()
+					+ Thread.currentThread().getName()).getBytes(),
                                       Base64.NO_WRAP);
         // Use this implementation if you don't want to keep filling
         // up your file system with temp files..


### PR DESCRIPTION
Minor issue: testing app by multiple downloading the same file.
    Thread name is added to avoid getting equal file names on ThreadPool
    execution when System.currentTimeMillis() easilly returns the same time.