### PR TITLE
Minor change to AcyronymJSONParser for defensive programming design.

### DIFF
--- a/ex/AcronymApplication/src/vandy/mooc/jsonacronym/AcronymJSONParser.java
+++ b/ex/AcronymApplication/src/vandy/mooc/jsonacronym/AcronymJSONParser.java
@@ -80,6 +80,7 @@ public class AcronymJSONParser {
                         acronyms = parseAcronymLongFormArray(reader);
                     break outerloop;
                 default:
+		    reader.skipValue();
                     Log.d(TAG, "weird problem with " + name + " field");
                     break;
                 }


### PR DESCRIPTION
Added in a reader.skipValue() to parseAcronymMessage(JsonReader) when there is error. This will prevent infinite loop (by consuming reader's 'next' ) if there ever is an unexpected value.
