### PR TITLE
Return empty list instead of null from Utils.getResults()

### DIFF
--- a/ex/AcronymApplication/src/vandy/mooc/jsonacronym/AcronymJSONParser.java
+++ b/ex/AcronymApplication/src/vandy/mooc/jsonacronym/AcronymJSONParser.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import android.util.JsonReader;
@@ -48,9 +49,9 @@ public class AcronymJSONParser {
 
         reader.beginArray();
         try {
-            // If the acronym wasn't expanded return null;
+            // If the acronym wasn't expanded return an empty list;
             if (reader.peek() == JsonToken.END_ARRAY)
-                return null;
+                return Collections.emptyList();
 
             // Create a JsonAcronym object for each element in the
             // Json array.
@@ -63,7 +64,7 @@ public class AcronymJSONParser {
     public List<JsonAcronym> parseAcronymMessage(JsonReader reader)
         throws IOException {
 
-        List<JsonAcronym> acronyms = null;
+        List<JsonAcronym> acronyms = new ArrayList<>();
         reader.beginObject();
 
         try {

--- a/ex/AcronymApplication/src/vandy/mooc/services/AcronymServiceAsync.java
+++ b/ex/AcronymApplication/src/vandy/mooc/services/AcronymServiceAsync.java
@@ -8,7 +8,6 @@ import vandy.mooc.aidl.AcronymResults;
 import vandy.mooc.utils.Utils;
 import android.content.Context;
 import android.content.Intent;
-import android.net.http.AndroidHttpClient;
 import android.os.IBinder;
 import android.os.RemoteException;
 import android.util.Log;
@@ -83,19 +82,21 @@ public class AcronymServiceAsync extends LifecycleLoggingService {
                 // possible expansions of the designated acronym.
                 List<AcronymData> acronymResults = 
                     Utils.getResults(acronym);
+                
+                Log.d(TAG, "" 
+                        + acronymResults.size() 
+                        + " results for acronym: " 
+                        + acronym);
 
                 // Invoke a one-way callback to send list of acronym
                 // expansions back to the AcronymActivity.
-                if (acronymResults != null) {
-                    Log.d(TAG, "" 
-                          + acronymResults.size() 
-                          + " results for acronym: " 
-                          + acronym);
+                if (acronymResults.size() > 0) {
                     callback.sendResults(acronymResults);
-                } else
+                } else {
                     callback.sendError("No expansions for " 
                                        + acronym
                                        + " found");
+                }
             }
 	};
 }

--- a/ex/AcronymApplication/src/vandy/mooc/services/AcronymServiceSync.java
+++ b/ex/AcronymApplication/src/vandy/mooc/services/AcronymServiceSync.java
@@ -1,6 +1,5 @@
 package vandy.mooc.services;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import vandy.mooc.aidl.AcronymCall;
@@ -80,22 +79,14 @@ public class AcronymServiceSync extends LifecycleLoggingService {
                 List<AcronymData> acronymResults = 
                     Utils.getResults(acronym);
 
-                if (acronymResults != null) {
-                    Log.d(TAG, "" 
-                          + acronymResults.size() 
-                          + " results for acronym: " 
-                          + acronym);
+                Log.d(TAG, "" 
+                		+ acronymResults.size() 
+                		+ " results for acronym: " 
+                		+ acronym);
 
-                    // Return the list of acronym expansions back to the
-                    // AcronymActivity.
-                    return acronymResults;
-                } else {
-                    // Create a zero-sized acronymResults object to
-                    // indicate to the caller that the acronym had no
-                    // expansions.
-                    acronymResults = new ArrayList<AcronymData>();
-                    return acronymResults;
-                }
+                // Return the list of acronym expansions back to the
+                // AcronymActivity.
+                return acronymResults;
             }
 	};
 }

--- a/ex/AcronymApplication/src/vandy/mooc/utils/Utils.java
+++ b/ex/AcronymApplication/src/vandy/mooc/utils/Utils.java
@@ -44,10 +44,10 @@ public class Utils {
         // Create a List that will return the AcronymData obtained
         // from the Acronym Service web service.
         final List<AcronymData> returnList = 
-            new ArrayList<AcronymData>();
+            new ArrayList<>();
             
         // A List of JsonAcronym objects.
-        List<JsonAcronym> jsonAcronyms = null;
+        List<JsonAcronym> jsonAcronyms = new ArrayList<>();
 
         try {
             // Append the location to create the full URL.
@@ -76,17 +76,15 @@ public class Utils {
             e.printStackTrace();
         }
 
-        if (jsonAcronyms != null && jsonAcronyms.size() > 0) {
-            // Convert the JsonAcronym data objects to our AcronymData
-            // object, which can be passed between processes.
-            for (JsonAcronym jsonAcronym : jsonAcronyms)
-                returnList.add(new AcronymData(jsonAcronym.getLongForm(),
-                                               jsonAcronym.getFreq(),
-                                               jsonAcronym.getSince()));
-             // Return the List of AcronymData.
-             return returnList;
-        }  else
-            return null;
+        // Convert the JsonAcronym data objects to our AcronymData
+        // object, which can be passed between processes.
+        for (JsonAcronym jsonAcronym : jsonAcronyms)
+        	returnList.add(new AcronymData(jsonAcronym.getLongForm(),
+        			jsonAcronym.getFreq(),
+        			jsonAcronym.getSince()));
+
+        // Return the List of AcronymData.
+        return returnList;
     }
 
     /**


### PR DESCRIPTION
Return empty list instead of null from Utils.getResults() to indicate no results found to avoid extra code for nullchecks. 
Not extensively tested but hopefully got it right.
Cheers 
Bo Andersson