### PR TITLE
Update ExecutorServiceTimeoutCache.java

### DIFF
--- a/ex/AcronymApplicationRetained/src/vandy/mooc/utils/ExecutorServiceTimeoutCache.java
+++ b/ex/AcronymApplicationRetained/src/vandy/mooc/utils/ExecutorServiceTimeoutCache.java
@@ -103,6 +103,15 @@ public class ExecutorServiceTimeoutCache<K, V>
                 }
             };
 
+
+        // Put a new CacheValues object into the ConcurrentHashMap
+        // associated with the key and return the previous
+        // CacheValues. There is no need to cancel the future
+        // from any previous cacheValues object that may be replaced
+        // by this put request since it's cleanupCacheRunnable future
+        // will not match this cacheValues object.
+        mResults.put(key, cacheValues);
+
         // Create a ScheduledFuture that will execute the
         // cleanupCacheRunnable after the designated timeout.
         ScheduledFuture<?> future =
@@ -110,25 +119,14 @@ public class ExecutorServiceTimeoutCache<K, V>
                                                timeout,
                                                TimeUnit.SECONDS);
 
-        // Set the future now that we have it.
+        // Now that we have a future, attach it to the cacheValues object
+        // that has already been safely added to the cache. The reason we
+        // do not set the future before adding the cacheValues object to the
+        // cache is because it is possible (but unlikely) for the future 
+        // to trigger in the small time window between when it is started
+        // and returned from the ScheduledExecutorService and when the 
+        // put() call is made to add it to the.
         cacheValues.setFuture(future);
-
-        // Put a new CacheValues object into the ConcurrentHashMap
-        // associated with the key and return the previous
-        // CacheValues.
-        CacheValues prevCacheValues =
-            mResults.put(key,
-                         cacheValues);
-
-        // If there was a previous CacheValues associated with this
-        // key then cancel the future immediately.  Note that there is
-        // no race condition between the ScheduledExecutorService
-        // running the cleanupCacheRunnable and canceling the future
-        // here since the ConcurrentHashMap.remove() call won't
-        // actually remove the key unless the value is equal to the
-        // original cacheValues reference.
-        if (prevCacheValues != null)
-            prevCacheValues.mFuture.cancel(true);
     }
 
     /**


### PR DESCRIPTION
Removed code that cancelled the future of any cacheValues object that may be being replaced by the put() operation. Also moved the creating and setting of the future after the put() call to ensure that the cacheValues object is safely in the cache before the future may possibly trigger.

Monte Creasor