### PR TITLE
Change comments about gaze time durations

### DIFF
--- a/assignments/assignment1/A1-Android-App/src/edu/vandy/MVP.java
+++ b/assignments/assignment1/A1-Android-App/src/edu/vandy/MVP.java
@@ -155,7 +155,7 @@ public interface MVP {
         /**
          * Create a resource manager that contains the designated
          * number of Palantir with random gaze times between 1 and 5
-         * milliseconds "Fair" semantics should be used to instantiate
+         * seconds "Fair" semantics should be used to instantiate
          * the Semaphore.
          *
          * @param palantiriCount

--- a/assignments/assignment1/A1-Android-App/src/edu/vandy/model/PalantiriModel.java
+++ b/assignments/assignment1/A1-Android-App/src/edu/vandy/model/PalantiriModel.java
@@ -55,7 +55,7 @@ public class PalantiriModel
 
     /**
      * Create a PalantiriManager that contains the designated number
-     * of Palantir with random gaze times between 1 and 5 milliseconds
+     * of Palantir with random gaze times between 1 and 5 seconds
      *
      * @param palantiriCount
      *            The number of Palantiri to add to the PalantiriManager.


### PR DESCRIPTION
Several comments mention gaze times between 1 and 5 ''milliseconds'; these should be 'seconds'.

Oh: MsCommentBug is not related to Microsoft :-)