### PR TITLE
Fixed manifest android:scheme:"" vs android:scheme:"file" issues.

### DIFF
--- a/assignments/assignment1/A1-Android-App/AndroidManifest.xml
+++ b/assignments/assignment1/A1-Android-App/AndroidManifest.xml
@@ -29,7 +29,6 @@
             <intent-filter>
                 <action android:name="android.intent.action.DISPLAY_IMAGES_SWIPE" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:scheme="" />
                 <data android:scheme="file" />
                 <data android:mimeType="image/*" />
             </intent-filter>
@@ -42,7 +41,6 @@
             <intent-filter>
                 <action android:name="android.intent.action.DISPLAY_IMAGES" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:scheme="" />
                 <data android:scheme="file" />
                 <data android:mimeType="image/*" />
             </intent-filter>

--- a/assignments/assignment1/A1-Android-App/src/vandy/mooc/view/DisplayImagesActivity.java
+++ b/assignments/assignment1/A1-Android-App/src/vandy/mooc/view/DisplayImagesActivity.java
@@ -85,7 +85,7 @@ public class DisplayImagesActivity
 
         // Retrieve the file path to the directory containing the
         // images to display from the intent.
-        mFilePath = getIntent().getDataString();
+        mFilePath = getIntent().getData().getPath();
 
         // Find the directory and load the directory as the source of
         // the imageAdapter.
@@ -110,8 +110,12 @@ public class DisplayImagesActivity
      */
     public static Intent makeIntent(Uri directoryPathname) {
         return new Intent(ACTION_DISPLAY_IMAGES)
-            .setDataAndType(directoryPathname,
-                            "image/*");
+                .setDataAndType(
+                        Uri.parse(directoryPathname.getPath())
+                                .buildUpon()
+                                .scheme("file")
+                                .build(),
+                        "image/*");
     }
 
     /**

--- a/assignments/assignment1/A1-Android-App/src/vandy/mooc/view/ViewPagerActivity.java
+++ b/assignments/assignment1/A1-Android-App/src/vandy/mooc/view/ViewPagerActivity.java
@@ -93,15 +93,19 @@ public class ViewPagerActivity extends FragmentActivity {
      * 
      * @param directoryPathname
      *            Filepath storing images to display
-     * @param pos
+     * @param position
      *            Position of starting image
      * @return
      */
     public static Intent makeIntent(String directoryPathname,
                                     int position) {
         return new Intent(ACTION_DISPLAY_IMAGES_SWIPE)
-            .setDataAndType(Uri.parse(directoryPathname),
-                            "image/*")
+                .setDataAndType(
+                        Uri.parse(directoryPathname)
+                                .buildUpon()
+                                .scheme("file")
+                                .build(),
+                        "image/*")
             .putExtra(ViewPagerActivity.CURRENT_IMAGE_POSITION, 
                       position);
     }
@@ -120,15 +124,15 @@ public class ViewPagerActivity extends FragmentActivity {
               + intent);
         Log.v(TAG,
               "2" 
-              + intent.getDataString());
+              + intent.getData());
 
         // If the intent exists and contains the filepath, extract its
         // data
-        if (intent != null && intent.getDataString() != null) {
+        if (intent != null && intent.getData() != null) {
             mCurrentImage =
                 intent.getIntExtra(CURRENT_IMAGE_POSITION,
                                    0);
-            mFilePath = intent.getDataString();
+            mFilePath = intent.getData().getPath();
         }
         Log.v(TAG,
               "mFilePath" 

--- a/assignments/assignment2/A2-Android-App/AndroidManifest.xml
+++ b/assignments/assignment2/A2-Android-App/AndroidManifest.xml
@@ -29,7 +29,6 @@
             <intent-filter>
                 <action android:name="android.intent.action.DISPLAY_IMAGES_SWIPE" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:scheme="" />
                 <data android:scheme="file" />
                 <data android:mimeType="image/*" />
             </intent-filter>
@@ -42,7 +41,6 @@
             <intent-filter>
                 <action android:name="android.intent.action.DISPLAY_IMAGES" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:scheme="" />
                 <data android:scheme="file" />
                 <data android:mimeType="image/*" />
             </intent-filter>

--- a/assignments/assignment2/A2-Android-App/src/vandy/mooc/view/DisplayImagesActivity.java
+++ b/assignments/assignment2/A2-Android-App/src/vandy/mooc/view/DisplayImagesActivity.java
@@ -85,7 +85,7 @@ public class DisplayImagesActivity
 
         // Retrieve the file path to the directory containing the
         // images to display from the intent.
-        mFilePath = getIntent().getDataString();
+        mFilePath = getIntent().getData().getPath();
 
         // Find the directory and load the directory as the source of
         // the imageAdapter.
@@ -110,8 +110,12 @@ public class DisplayImagesActivity
      */
     public static Intent makeIntent(Uri directoryPathname) {
         return new Intent(ACTION_DISPLAY_IMAGES)
-            .setDataAndType(directoryPathname,
-                            "image/*");
+                .setDataAndType(
+                        Uri.parse(directoryPathname.getPath())
+                                .buildUpon()
+                                .scheme("file")
+                                .build(),
+                        "image/*");
     }
 
     /**

--- a/assignments/assignment2/A2-Android-App/src/vandy/mooc/view/ViewPagerActivity.java
+++ b/assignments/assignment2/A2-Android-App/src/vandy/mooc/view/ViewPagerActivity.java
@@ -100,10 +100,14 @@ public class ViewPagerActivity extends FragmentActivity {
     public static Intent makeIntent(String directoryPathname,
                                     int position) {
         return new Intent(ACTION_DISPLAY_IMAGES_SWIPE)
-            .setDataAndType(Uri.parse(directoryPathname),
-                            "image/*")
-            .putExtra(ViewPagerActivity.CURRENT_IMAGE_POSITION, 
-                      position);
+                .setDataAndType(
+                        Uri.parse(directoryPathname)
+                                .buildUpon()
+                                .scheme("file")
+                                .build(),
+                        "image/*")
+                .putExtra(ViewPagerActivity.CURRENT_IMAGE_POSITION,
+                        position);
     }
 
     /**
@@ -120,15 +124,15 @@ public class ViewPagerActivity extends FragmentActivity {
               + intent);
         Log.v(TAG,
               "2" 
-              + intent.getDataString());
+              + intent.getData());
 
         // If the intent exists and contains the filepath, extract its
         // data
-        if (intent != null && intent.getDataString() != null) {
+        if (intent != null && intent.getData() != null) {
             mCurrentImage =
                 intent.getIntExtra(CURRENT_IMAGE_POSITION,
                                    0);
-            mFilePath = intent.getDataString();
+            mFilePath = intent.getData().getPath();
         }
         Log.v(TAG,
               "mFilePath" 


### PR DESCRIPTION
This solution is the more complicated one that properly uses "file:" schemes for the DisplayImagesAcitivity and the ViewPagerActivity.

An alternative, much more simple solution, is to simply remove both pairs of android:scheme:"" and android:scheme:"file" entries from the manifest which requires no java code changes and works just as well (but which inhibits external use of both activities since they don't follow the normal URL scheming conventions).