### PR TITLE
Enhanced A1-Test-App and A2-Test-App to automatically generate best download wait times

### DIFF
--- a/assignments/assignment1/A1-Android-Test/src/vandy/mooc/tests/DownloadImagesActivityBaseTest.java
+++ b/assignments/assignment1/A1-Android-Test/src/vandy/mooc/tests/DownloadImagesActivityBaseTest.java
@@ -28,14 +28,21 @@ public class DownloadImagesActivityBaseTest extends ActivityInstrumentationTestC
      * A list of valid URLs to test the download of a valid images.
      * This array is used to test the download of a single valid image
      * as well as again to test the download of multiple valid images.
+     * These images are ordered from largest to smallest in size.
      */
     protected static final String mValidUrlList[] =
-        {"http://www.hireworks.tv/wp-content/gallery/bout_us/gameofthrones.jpg",
+         // 163 KB
+        {"http://s1.ibtimes.com/sites/www.ibtimes.com/files/2015/06/11/game-thrones-coloring-book.jpg",
+         // 151 KB
          "http://colleges.usnews.rankingsandreviews.com/img/college-photo_313._445x280-zmm.jpg",
+         // 144 KB
+         "http://static.tumblr.com/a5fa27964cfba9a928dd51f93d648375/24rnppg/LeFndriav/tumblr_static_876b2abic1kwkcw884s40cgw0.jpg",
+         // 84 KB
          "http://www.dre.vanderbilt.edu/~schmidt/gifs/dougs-xsmall.jpg",
-         "http://funny-pics-fun.com/wp-content/uploads/Very-Funny-Baby-Faces-13.jpg",
-         "http://2.bp.blogspot.com/-c2U3HUQZVy8/UV7KI2bodLI/AAAAAAAAA4g/DJEEmv-FmNY/s1600/galaxy_universe-normal.jpg",
+         // 48 KB
          "http://acidcow.com/pics/20110920/famous_actors_who_got_hit_with_the_ugly_stick_19.jpg",
+         // 28 KB
+         "http://funny-pics-fun.com/wp-content/uploads/Very-Funny-Baby-Faces-13.jpg",
         };
 
     /**

--- a/assignments/assignment1/A1-Android-Test/src/vandy/mooc/tests/TestTimeTuningManager.java
+++ b/assignments/assignment1/A1-Android-Test/src/vandy/mooc/tests/TestTimeTuningManager.java
@@ -1,0 +1,127 @@
+package vandy.mooc.tests;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.util.Log;
+import junit.framework.Assert;
+
+import java.util.Calendar;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Created by Monte on 2015-12-22.
+ */
+public class TestTimeTuningManager {
+    /**
+     * Students should adjust this value to a value that will
+     * ensure that the largest test image can be successfully
+     * downloaded. To determine this value, run the
+     * Test4_singleValidUrl which downloads and displays the
+     * largest image used in this test suite.
+     */
+    private static final int MAX_DOWNLOAD_SECONDS_PER_IMAGE = 200;
+    private static final int MIN_DOWNLOAD_SECONDS_PER_IMAGE = 5;
+
+    /**
+     * Shared preference key for saving/restoring the calculated
+     * download seconds parameter. This value is calculated
+     * automatically when each time Test4_SingleValidUrl is run
+     * and then is used to calculate the wait time for downloading
+     * multiple images.
+     */
+    public static final String SHARED_PREF_KEY = "DownloadSecs";
+
+    /**
+     * Keeps track of the start time when attempting to
+     * determine how long it takes to download the largest
+     * image in the test dataset.
+     */
+    private static long mStartTime;
+
+    /**
+     * Since the wait time for the DownloadImageActivity is
+     * dependant not only on the connection speed, but also
+     * on how many images are being downloaded (and their
+     * sizes), this method estimates the download wait time
+     * based on the number of expected images that are being
+     * downloaded. It does not take into account the size of
+     * each image, so the DOWNLOAD_SECONDS_PER_IMAGE should be
+     * set to some value greater than the estimated time to
+     * download and display the largest image.
+     * @param numImages
+     * @return
+     */
+    public static int getDownloadWaitTime(Context context, int numImages) {
+        SharedPreferences prefs =
+                PreferenceManager.getDefaultSharedPreferences(context);
+
+        int downloadSecsPerImage =
+                prefs.getInt(SHARED_PREF_KEY, MAX_DOWNLOAD_SECONDS_PER_IMAGE);
+
+        int secs = downloadSecsPerImage * numImages;
+
+        Log.w("DOWNLOAD TUNING MESSAGE",
+                "Estimating download of " + numImages
+                        + " images will take " + secs + " seconds.");
+
+        return (int)TimeUnit.SECONDS.toMillis(secs);
+    }
+
+    /**
+     * Called to get a ridiculously long wait time when downloading
+     * the single valid image (Test4_SingleValidImage) the purpose of
+     * which is to ensure that the operation can complete even on the
+     * slowest of connections. The resulting calculated time can then
+     * be used to determine the appropriate wait time for downloading
+     * multiple images.
+     *
+     * @return a very very long wait time, guaranteed to not timeout.
+     */
+    public static int getMaxDownloadWaitTime() {
+        return (int)TimeUnit.SECONDS.toMillis(MAX_DOWNLOAD_SECONDS_PER_IMAGE);
+    }
+
+    /**
+     * Starts a time before downloading the largest image during
+     * the Test4_SingleValidUrl test.
+     *
+     * @return the start time of the timing operation.
+     */
+    public static long startTimer() {
+        mStartTime = Calendar.getInstance().getTimeInMillis();
+        return mStartTime;
+    }
+
+    /**
+     * Determines the total number of seconds to it took to
+     * download the largest image from Test4_SingleValidUrl and
+     * saves this value in the registry which can the be retrieved
+     * by calling getDownloadWaitTime() used for downloading
+     * multiple images.
+     *
+     * @param context for accessing shared preferences
+     * @return the number of seconds it too to download the image.
+     */
+    public static long stopTimerAndSaveResults(Context context) {
+        long stopTime = Calendar.getInstance().getTimeInMillis();
+        long duration = stopTime - mStartTime;
+        int secs = (int)TimeUnit.MILLISECONDS.toSeconds(duration);
+        secs += secs * 0.20;
+        secs = Math.max(secs, MIN_DOWNLOAD_SECONDS_PER_IMAGE);
+
+        Log.w("DOWNLOAD TUNING MESSAGE",
+                "TestWaitTimeTuningParameter.java automatically adjusting "
+                        + "estimated download time for each image to be "
+                        + secs + " seconds.");
+        SharedPreferences prefs =
+                PreferenceManager.getDefaultSharedPreferences(context);
+
+        SharedPreferences.Editor editor = prefs.edit();
+        editor.putInt(SHARED_PREF_KEY, secs);
+        Assert.assertTrue(editor.commit());
+
+        return secs;
+    }
+}
+

--- a/assignments/assignment1/A1-Android-Test/src/vandy/mooc/tests/TestUrlsHelper.java
+++ b/assignments/assignment1/A1-Android-Test/src/vandy/mooc/tests/TestUrlsHelper.java
@@ -110,7 +110,9 @@ public class TestUrlsHelper {
             // Check for invalid URL toasts.
             Assert.assertTrue("Test failed: No Toast shown for "
                             + invalidCount + " invalid URL(s)",
-                    solo.waitForText("failed to download!"));
+                    solo.waitForText("failed to download!", 1,
+                            TestTimeTuningManager.getDownloadWaitTime(
+                                    solo.getCurrentActivity(), 1)));
         }
 
         if (validCount == 0) {
@@ -120,9 +122,34 @@ public class TestUrlsHelper {
                     solo.waitForActivity(
                             DisplayImagesActivity.class, shortDelay));
         } else {
+
+            // Special case for downloading a single valid image is used
+            // to calculate the download wait time to set for later multiple
+            // image download tests.
+            if (validCount == 1) {
+                TestTimeTuningManager.startTimer();
+
+                // Wait for the DisplayImagesActivity with a really long
+                // timeout to ensure that it can complete. Once completed
+                // the call t ostopTimerAndSaveResults() will store the
+                // time it took to download this (the largest image) and
+                // use it to later estimate how long to wait for tests
+                // which attempt to download multiple images.
+                Assert.assertTrue("Test failed: DownloadImageActivity failed to start",
+                        solo.waitForActivity(
+                                DisplayImagesActivity.class,
+                                TestTimeTuningManager.getMaxDownloadWaitTime()));
+
+                TestTimeTuningManager.stopTimerAndSaveResults(
+                        solo.getCurrentActivity());
+            } else {
             // Ensure that the display images activity was started.
             Assert.assertTrue("Test failed: DownloadImageActivity failed to start",
-                    solo.waitForActivity(DisplayImagesActivity.class));
+                        solo.waitForActivity(
+                                DisplayImagesActivity.class,
+                                TestTimeTuningManager.getDownloadWaitTime(
+                                        solo.getCurrentActivity(), validCount)));
+            }
 
             // Now check if the proper number of images were
             // successfully downloaded.

--- a/assignments/assignment2/A2-Android-Test/src/vandy/mooc/tests/DownloadImagesActivityBaseTest.java
+++ b/assignments/assignment2/A2-Android-Test/src/vandy/mooc/tests/DownloadImagesActivityBaseTest.java
@@ -28,15 +28,22 @@ public class DownloadImagesActivityBaseTest extends ActivityInstrumentationTestC
      * A list of valid URLs to test the download of a valid images.
      * This array is used to test the download of a single valid image
      * as well as again to test the download of multiple valid images.
+     * These images are ordered from largest to smallest in size.
      */
-    protected static final String mValidUrlList[] =
-        {"http://www.hireworks.tv/wp-content/gallery/bout_us/gameofthrones.jpg",
-         "http://colleges.usnews.rankingsandreviews.com/img/college-photo_313._445x280-zmm.jpg",
-         "http://www.dre.vanderbilt.edu/~schmidt/gifs/dougs-xsmall.jpg",
-         "http://funny-pics-fun.com/wp-content/uploads/Very-Funny-Baby-Faces-13.jpg",
-         "http://2.bp.blogspot.com/-c2U3HUQZVy8/UV7KI2bodLI/AAAAAAAAA4g/DJEEmv-FmNY/s1600/galaxy_universe-normal.jpg",
-         "http://acidcow.com/pics/20110920/famous_actors_who_got_hit_with_the_ugly_stick_19.jpg",
-        };
+    protected static final String mValidUrlList[] = {
+            // 163 KB
+            "http://s1.ibtimes.com/sites/www.ibtimes.com/files/2015/06/11/game-thrones-coloring-book.jpg",
+            // 151 KB
+            "http://colleges.usnews.rankingsandreviews.com/img/college-photo_313._445x280-zmm.jpg",
+            // 144 KB
+            "http://static.tumblr.com/a5fa27964cfba9a928dd51f93d648375/24rnppg/LeFndriav/tumblr_static_876b2abic1kwkcw884s40cgw0.jpg",
+            // 84 KB
+            "http://www.dre.vanderbilt.edu/~schmidt/gifs/dougs-xsmall.jpg",
+            // 48 KB
+            "http://acidcow.com/pics/20110920/famous_actors_who_got_hit_with_the_ugly_stick_19.jpg",
+            // 28 KB
+            "http://funny-pics-fun.com/wp-content/uploads/Very-Funny-Baby-Faces-13.jpg"};
+
 
     /**
      * A list of invalid URLs to test the handling of invalid images.

--- a/assignments/assignment2/A2-Android-Test/src/vandy/mooc/tests/TestTimeTuningManager.java
+++ b/assignments/assignment2/A2-Android-Test/src/vandy/mooc/tests/TestTimeTuningManager.java
@@ -1,0 +1,127 @@
+package vandy.mooc.tests;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.util.Log;
+import junit.framework.Assert;
+
+import java.util.Calendar;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Created by Monte on 2015-12-22.
+ */
+public class TestTimeTuningManager {
+    /**
+     * Students should adjust this value to a value that will
+     * ensure that the largest test image can be successfully
+     * downloaded. To determine this value, run the
+     * Test4_singleValidUrl which downloads and displays the
+     * largest image used in this test suite.
+     */
+    private static final int MAX_DOWNLOAD_SECONDS_PER_IMAGE = 200;
+    private static final int MIN_DOWNLOAD_SECONDS_PER_IMAGE = 5;
+
+    /**
+     * Shared preference key for saving/restoring the calculated
+     * download seconds parameter. This value is calculated
+     * automatically when each time Test4_SingleValidUrl is run
+     * and then is used to calculate the wait time for downloading
+     * multiple images.
+     */
+    public static final String SHARED_PREF_KEY = "DownloadSecs";
+
+    /**
+     * Keeps track of the start time when attempting to
+     * determine how long it takes to download the largest
+     * image in the test dataset.
+     */
+    private static long mStartTime;
+
+    /**
+     * Since the wait time for the DownloadImageActivity is
+     * dependant not only on the connection speed, but also
+     * on how many images are being downloaded (and their
+     * sizes), this method estimates the download wait time
+     * based on the number of expected images that are being
+     * downloaded. It does not take into account the size of
+     * each image, so the DOWNLOAD_SECONDS_PER_IMAGE should be
+     * set to some value greater than the estimated time to
+     * download and display the largest image.
+     * @param numImages
+     * @return
+     */
+    public static int getDownloadWaitTime(Context context, int numImages) {
+        SharedPreferences prefs =
+                PreferenceManager.getDefaultSharedPreferences(context);
+
+        int downloadSecsPerImage =
+                prefs.getInt(SHARED_PREF_KEY, MAX_DOWNLOAD_SECONDS_PER_IMAGE);
+
+        int secs = downloadSecsPerImage * numImages;
+
+        Log.w("DOWNLOAD TUNING MESSAGE",
+                "Estimating download of " + numImages
+                        + " images will take " + secs + " seconds.");
+
+        return (int)TimeUnit.SECONDS.toMillis(secs);
+    }
+
+    /**
+     * Called to get a ridiculously long wait time when downloading
+     * the single valid image (Test4_SingleValidImage) the purpose of
+     * which is to ensure that the operation can complete even on the
+     * slowest of connections. The resulting calculated time can then
+     * be used to determine the appropriate wait time for downloading
+     * multiple images.
+     *
+     * @return a very very long wait time, guaranteed to not timeout.
+     */
+    public static int getMaxDownloadWaitTime() {
+        return (int)TimeUnit.SECONDS.toMillis(MAX_DOWNLOAD_SECONDS_PER_IMAGE);
+    }
+
+    /**
+     * Starts a time before downloading the largest image during
+     * the Test4_SingleValidUrl test.
+     *
+     * @return the start time of the timing operation.
+     */
+    public static long startTimer() {
+        mStartTime = Calendar.getInstance().getTimeInMillis();
+        return mStartTime;
+    }
+
+    /**
+     * Determines the total number of seconds to it took to
+     * download the largest image from Test4_SingleValidUrl and
+     * saves this value in the registry which can the be retrieved
+     * by calling getDownloadWaitTime() used for downloading
+     * multiple images.
+     *
+     * @param context for accessing shared preferences
+     * @return the number of seconds it too to download the image.
+     */
+    public static long stopTimerAndSaveResults(Context context) {
+        long stopTime = Calendar.getInstance().getTimeInMillis();
+        long duration = stopTime - mStartTime;
+        int secs = (int)TimeUnit.MILLISECONDS.toSeconds(duration);
+        secs += secs * 0.20;
+        secs = Math.max(secs, MIN_DOWNLOAD_SECONDS_PER_IMAGE);
+
+        Log.w("DOWNLOAD TUNING MESSAGE",
+                "TestWaitTimeTuningParameter.java automatically adjusting "
+                        + "estimated download time for each image to be "
+                        + secs + " seconds.");
+        SharedPreferences prefs =
+                PreferenceManager.getDefaultSharedPreferences(context);
+
+        SharedPreferences.Editor editor = prefs.edit();
+        editor.putInt(SHARED_PREF_KEY, secs);
+        Assert.assertTrue(editor.commit());
+
+        return secs;
+    }
+}
+

--- a/assignments/assignment2/A2-Android-Test/src/vandy/mooc/tests/TestUrlsHelper.java
+++ b/assignments/assignment2/A2-Android-Test/src/vandy/mooc/tests/TestUrlsHelper.java
@@ -110,7 +110,9 @@ public class TestUrlsHelper {
             // Check for invalid URL toasts.
             Assert.assertTrue("Test failed: No Toast shown for "
                             + invalidCount + " invalid URL(s)",
-                    solo.waitForText("failed to download!"));
+                    solo.waitForText("failed to download!", 1,
+                            TestTimeTuningManager.getDownloadWaitTime(
+                                    solo.getCurrentActivity(), 1)));
         }
 
         if (validCount == 0) {
@@ -120,9 +122,34 @@ public class TestUrlsHelper {
                     solo.waitForActivity(
                             DisplayImagesActivity.class, shortDelay));
         } else {
-            // Ensure that the display images activity was started.
-            Assert.assertTrue("Test failed: DownloadImageActivity failed to start",
-                    solo.waitForActivity(DisplayImagesActivity.class));
+
+            // Special case for downloading a single valid image is used
+            // to calculate the download wait time to set for later multiple
+            // image download tests.
+            if (validCount == 1) {
+                TestTimeTuningManager.startTimer();
+
+                // Wait for the DisplayImagesActivity with a really long
+                // timeout to ensure that it can complete. Once completed
+                // the call t ostopTimerAndSaveResults() will store the
+                // time it took to download this (the largest image) and
+                // use it to later estimate how long to wait for tests
+                // which attempt to download multiple images.
+                Assert.assertTrue("Test failed: DownloadImageActivity failed to start",
+                        solo.waitForActivity(
+                                DisplayImagesActivity.class,
+                                TestTimeTuningManager.getMaxDownloadWaitTime()));
+
+                TestTimeTuningManager.stopTimerAndSaveResults(
+                        solo.getCurrentActivity());
+            } else {
+                // Ensure that the display images activity was started.
+                Assert.assertTrue("Test failed: DownloadImageActivity failed to start",
+                        solo.waitForActivity(
+                                DisplayImagesActivity.class,
+                                TestTimeTuningManager.getDownloadWaitTime(
+                                        solo.getCurrentActivity(), validCount)));
+            }
 
             // Now check if the proper number of images were
             // successfully downloaded.


### PR DESCRIPTION
Added code to automatically adjust the waitForActivity() call for the DisplayImagesActivity. The calculation is based on the largest image in the image test set and takes into consideration the connection speed on each machine that it is run on. This solution does not require the students to ever have to make changes to waitTime constants. It has been tested on the fastest possible connection as well as the slowest possible connection (which takes roughly 10 minutes to download 6 images since I used GSM and GPRS, and I also tested it with EDGE speed).

I think you will get very few complaints with this design in the future. It is worth noting that Test4_SingleValidUrl is used to set the best wait time for the specific uses and their connection speed. The Images have also been changed: I remove 2 of the larger images that exceed 1000KB and replaced them with ones that are around 150KB (and those are to two largest now).